### PR TITLE
Fix use of CODE_TESTS_WORKSPACE in test command

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -30,7 +30,7 @@ var stream = remote(downloadUrl, { base: '' })
 stream.on('end', function () {
     var executable = process.platform === 'darwin' ? darwinExecutable : linuxExecutable;
     var args = [
-        testsFolder,
+        testsWorkspace,
         '--extensionDevelopmentPath=' + process.cwd(),
         '--extensionTestsPath=' + testsFolder
     ];


### PR DESCRIPTION
[java json rusnc SQL]() `<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.`